### PR TITLE
Fix tutorials filter by service

### DIFF
--- a/src/lib/components/Tutorials.svelte
+++ b/src/lib/components/Tutorials.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { base } from "$app/paths";
-  import type { ExternalTutorial, Link, Tutorial } from "$lib/types";
+  import type { ExternalTutorial, Tutorial } from "$lib/types";
   import account from "@material-design-icons/svg/outlined/account_box.svg?raw";
   import email from "@material-design-icons/svg/outlined/email.svg?raw";
   import download from "@material-design-icons/svg/outlined/file_download.svg?raw";
@@ -10,17 +10,25 @@
   import SvgIcon from "./SvgIcon.svelte";
 
   export let tutorials: Tutorial[];
-  export let links: Link[];
 
-  const selectedFilters: Record<string, boolean> = links.reduce(
-    (acc, link) => ({ ...acc, [link.slug]: false }),
+  // Get all services which are used in tutorials except "Générique"
+  const services: string[] = tutorials.reduce(
+    (list: string[], { service }) =>
+      list.includes(service) || service === "Générique"
+        ? list
+        : [...list, service],
+    []
+  );
+
+  const selectedFilters: Record<string, boolean> = services.reduce(
+    (acc, service) => ({ ...acc, [service]: false }),
     {}
   );
 
   let noFilterSelected = true;
 
-  const onClickFilter = (slug: string) => {
-    selectedFilters[slug] = !selectedFilters[slug];
+  const onClickFilter = (service: string) => {
+    selectedFilters[service] = !selectedFilters[service];
     noFilterSelected = !hasAnyFilterActive();
   };
 
@@ -70,13 +78,13 @@
       >Filtrer les tutoriels par service</span
     >
     <div>
-      {#each links as { title }}
+      {#each services as service}
         <button
           class="tutorials--filter"
-          class:tutorials--filter-selected={selectedFilters[title]}
-          on:click={() => onClickFilter(title)}
+          class:tutorials--filter-selected={selectedFilters[service]}
+          on:click={() => onClickFilter(service)}
         >
-          {title}
+          {service}
         </button>
       {/each}
     </div>

--- a/src/lib/components/Tutorials.svelte
+++ b/src/lib/components/Tutorials.svelte
@@ -20,9 +20,8 @@
     []
   );
 
-  const selectedFilters: Record<string, boolean> = services.reduce(
-    (acc, service) => ({ ...acc, [service]: false }),
-    {}
+  const selectedFilters = Object.fromEntries(
+    services.map((service) => [service, false])
   );
 
   let noFilterSelected = true;

--- a/src/routes/(default)/+page.svelte
+++ b/src/routes/(default)/+page.svelte
@@ -35,7 +35,7 @@
     <Links links={data.links} categories={data.categories} bind:favorites />
   </div>
   <div class="bottom--container">
-    <Tutorials tutorials={data.tutorials} links={data.links} />
+    <Tutorials tutorials={data.tutorials} />
     <Resources resources={data.resources} />
   </div>
 </section>


### PR DESCRIPTION
Lié à l'ano que Claire a remonté à savoir : les filtres par service sur les tutos ne fonctionnent pas

Ca venait du fait qu'on comparait "Compte CFP" (nom du service dans le tuto) avec "CPF" (nom du lien externe), et pareil pour les autres catégories

Du coup là j'affiche que les services qui ont au moins un tuto lié et avec le nom qu'on voit dans tuto coté admin